### PR TITLE
Fix argument for new_transport in post endpoint

### DIFF
--- a/apis/rest/transport.py
+++ b/apis/rest/transport.py
@@ -25,7 +25,7 @@ class TransportEndpoint(Resource):
     @authorized_groups(['StandardWrite'])
     def post(self):
         args = transport_parser.parse_args()
-        response = new_transport(transport_type=args['TransportType'])
+        response = new_transport(name=args['Name'])
         return jsonify(response)
 
     @authorized_groups(['StandardWrite', 'Transport'])


### PR DESCRIPTION
Calling API for create new transport via curl, return a 500 error.

[new_transport](https://github.com/FactionC2/API/blob/master/processing/transport.py) function imported from processing.transport need as argument the name of the transport.