### PR TITLE
Alternative logging options

### DIFF
--- a/backend/rabbitmq.py
+++ b/backend/rabbitmq.py
@@ -38,8 +38,9 @@ class Consumer(object):
                 rabbit_connected = True
                 log("rabbitmq-consumer:open", "RabbitMQ is up!")
                 connection.close()
-            except:
+            except Exception as e:
                 rabbit_connected = False
+                log("rabbitmq-consumer:open", f"Connection Error: {str(e)}")
                 log("rabbitmq-consumer:open", "RabbitMQ not reachable.. waiting..")
                 sleep(2)
 

--- a/docker_build/logging.generic.conf
+++ b/docker_build/logging.generic.conf
@@ -1,0 +1,28 @@
+[loggers]
+keys=root, gunicorn.info
+
+[handlers]
+keys=console
+
+[formatters]
+keys=generic
+
+[logger_root]
+level=INFO
+handlers=console
+
+[logger_gunicorn.info]
+level=INFO
+handlers=console
+propagate=0
+qualname=gunicorn.info
+
+[handler_console]
+class=StreamHandler
+formatter=generic
+args=(sys.stdout, )
+
+[formatter_generic]
+format=%(asctime)s [%(process)d] [%(levelname)s] %(message)s
+datefmt=%Y-%m-%d %H:%M:%S
+class=logging.Formatter

--- a/logger/__init__.py
+++ b/logger/__init__.py
@@ -1,6 +1,18 @@
 from datetime import datetime
+import logging
+from os import environ
 
+default_level = logging.INFO
 
-def log(source, message):
-    print("({0})[{1}] - {2}".format(datetime.now().strftime("%m/%d %H:%M:%S"), source, message))
+def log(source, message, level="info"):
+    msg = f"[{source}] - {message}"
+    
+    if int(environ.get("USE_NATIVE_LOGGER", 0)) == 1:
+        if not isinstance(level, int):
+            level = getattr(logging, level.upper(), default_level)
+        logger = logging.getLogger()
+        logger.log(level, msg)
+
+    else:
+        print("({0}){1}".format(datetime.now().strftime("%m/%d %H:%M:%S"), msg))
 

--- a/logger/__init__.py
+++ b/logger/__init__.py
@@ -5,8 +5,8 @@ from os import environ
 default_level = logging.INFO
 
 def log(source, message, level="info"):
-    msg = f"[{source}] - {message}"
-    
+    msg = f"[{str(source)}] - {str(message)}"
+
     if int(environ.get("USE_NATIVE_LOGGER", 0)) == 1:
         if not isinstance(level, int):
             level = getattr(logging, level.upper(), default_level)


### PR DESCRIPTION
This PR adds an environment called "USE_NATIVE_LOGGER". When present, the log method will use native logging instead of print. This is to maintain compatibility when current workflows but also esolve this issue: https://github.com/FactionC2/Faction/issues/35 

I also added an alternative logging.conf with generic options and a more verbose level to docker_build. This file is more or less ignored but can be mounted as a volume in docker if you wish to increase logging and avoid using json.

Finally, I also added slightly better error reporting for when the API cannot connect to MQ. This makes it so you can identify network issues easier.

