### PR TITLE
Allow for Custom Gunicorn Options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,36 @@
 ﻿# Largely taken from https://sebest.github.io/post/protips-using-gunicorn-inside-a-docker-image/
 
 FROM alpine:3.8
+
+# server specific variables
+ENV GUNICORN_SERVER gunicorn
+ENV GUNICORN_WORKER_CLASS eventlet
+ENV GUNICORN_WORKERS 1
+ENV GUNICORN_LOGGING_CONFIG /app/logging.conf
+# if developing, set timeout to something low like 3 or 5
+ENV GUNICORN_TIMEOUT 300
+ENV GUNICORN_BIND_ADDRESS 0.0.0.0
+ENV GUNICORN_BIND_PORT 5000
+ENV GUNICORN_DEBUG 0
+ENV GUNICORN_RELOAD 0
+ENV GUNICORN_OPTS ""
+
+# api variables
+ENV API_UPLOAD_DIR /opt/faction/uploads
+ENV POSTGRES_HOST db
+ENV POSTGRES_DATABASE faction
+ENV POSTGRES_USERNAME postgres
+ENV RABBIT_HOST mq
+ENV RABBIT_USERNAME guest
+ENV USE_NATIVE_LOGGER 0
+# this is only used when GUNICORN_SERVER is "flask"
+ENV DEFAULT_LOGGING_LEVEL INFO
+
+# api secrets: leave these uncommented so that the user is forced to set them
+# ENV FLASK_SECRET ""
+# ENV POSTGRES_PASSWORD ""
+# ENV RABBIT_PASSWORD ""
+
 RUN apk add --no-cache \
             python3 \
             py3-gunicorn \
@@ -12,23 +42,43 @@ RUN apk add --no-cache \
             musl-dev \
             gcc \
             postgresql-dev
-ADD . /app
+
+# symlink to expose "python" command
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+# make default upload directory
+RUN mkdir -p /opt/faction/uploads
+
+RUN mkdir /app
 WORKDIR /app
-COPY ./docker_build/logging.conf /app/logging.conf
+
 RUN addgroup -S -g 1337 gunicorn && \
     adduser -S -G gunicorn -u 1337 gunicorn && \
     pip3 install --upgrade pip  && \
-    pip3 install pipenv  && \
-    pipenv install --system && \
+    pip3 install pipenv && \
     mkdir -p ./cache && \
     chown gunicorn:gunicorn ./cache
+
+# add Pipfile and install dependencies before adding /app
+COPY Pipfile /app/Pipfile
+COPY Pipfile.lock /app/Pipfile.lock
+RUN pipenv install --system
+
+# add and configure startup.sh file
+COPY startup.sh /opt/startup.sh 
+RUN chmod +x /opt/startup.sh
+RUN chown gunicorn:gunicorn /opt/startup.sh
+
+# give gunicorn control over default upload path
+RUN chown gunicorn:gunicorn /opt/faction/uploads
+
+# add core app files
+COPY ./docker_build/logging.conf /app/logging.conf
+ADD . /app
+RUN chmod +x /app/app.py
+
 EXPOSE 5000
 
 USER gunicorn
-CMD ["/usr/bin/gunicorn", \
-  "--worker-class", "eventlet", \
-  "--workers", "1", \
-  "--log-config", "/app/logging.conf", \
-  "--timeout", "300", \
-  "--bind", "0.0.0.0:5000", \
-  "app:app" ]
+
+ENTRYPOINT ["/opt/startup.sh"]

--- a/logger/__init__.py
+++ b/logger/__init__.py
@@ -2,15 +2,25 @@ from datetime import datetime
 import logging
 from os import environ
 
-default_level = logging.INFO
+DEFAULT_LEVEL_STR = environ.get("DEFAULT_LOGGING_LEVEL", "INFO")
+DEFAULT_LEVEL = getattr(logging, DEFAULT_LEVEL_STR.upper(), "INFO")
+ROOT_LOGGER = logging.getLogger() # get root logger
+
+if environ.get("GUNICORN_SERVER", "gunicorn") == "flask":
+    ROOT_LOGGER.setLevel(DEFAULT_LEVEL) # set default level if using the flask server
 
 def log(source, message, level="info"):
     msg = f"[{str(source)}] - {str(message)}"
 
     if int(environ.get("USE_NATIVE_LOGGER", 0)) == 1:
         if not isinstance(level, int):
-            level = getattr(logging, level.upper(), default_level)
-        logger = logging.getLogger()
+            level = getattr(logging, level.upper(), DEFAULT_LEVEL)
+        logger = logging.getLogger() # get root logger
+        if len(logger.handlers) < 1: # if no handlers are passed in, setup default console handler
+            ch = logging.StreamHandler()
+            ch.setLevel(DEFAULT_LEVEL)
+            logger.addHandler(ch)
+            logger.log(DEFAULT_LEVEL, "[logger] - Setting Up Default Handler at level 'INFO' Becase No Handlers Were Found")
         logger.log(level, msg)
 
     else:

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+# allow the application dir to be overidden to run locally
+GUNICORN_API_DIR=${GUNICORN_API_DIR:-/app}
+
+function gunicorn_run() {
+    # define default opts
+    gunicorn_bind_address="${GUNICORN_BIND_ADDRESS:-0.0.0.0}";
+    gunicorn_bind_port="${GUNICORN_BIND_PORT:-5000}";
+    gunicorn_bind="${gunicorn_bind_address}:${gunicorn_bind_port}";
+
+    # flask socketio may have restrictions on workers, default to 1
+    gunicorn_workers="${GUNICORN_WORKERS:-1}";
+
+    # set to low value like 3 or 5 to get reloading working
+    gunicorn_timeout="${GUNICORN_TIMEOUT:-20}";
+    
+    # combine default opts
+    gunicorn_opts="--workers $gunicorn_workers --timeout $gunicorn_timeout --bind $gunicorn_bind";
+
+    # define and set option opts
+    # allow the ability to worker_class and log_config to empty string to skip options
+    gunicorn_worker_class="${GUNICORN_WORKER_CLASS}";
+    if [ ${#gunicorn_worker_class} -gt 0 ]; then
+        gunicorn_opts="$gunicorn_opts --worker-class $gunicorn_worker_class";
+    fi
+
+    gunicorn_logging_config="${GUNICORN_LOGGING_CONFIG}";
+    if [ ${#gunicorn_logging_config} -gt 0 ]; then
+        gunicorn_opts="$gunicorn_opts --log-config $gunicorn_logging_config";
+    fi
+
+    # configure debug/reloading
+    gunicorn_reload="${GUNICORN_RELOAD:-0}";
+    gunicorn_debug="${GUNICORN_DEBUG:-0}";
+    if [ "${gunicorn_debug}" == "1" ]; then
+        gunicorn_opts="$gunicorn_opts --reload";
+    elif [ "${gunicorn_reload}" == "1" ]; then
+        gunicorn_opts="$gunicorn_opts --reload";
+    fi
+
+    # set custom options
+    if [ ${#GUNICORN_OPTS} -gt 1 ]; then
+        gunicorn_opts="${gunicorn_opts} ${GUNICORN_OPTS}";
+    fi
+
+    echo "Gunicorn Options: $gunicorn_opts";
+    echo "Starting gunicorn...";
+    exec gunicorn $gunicorn_opts app:app;
+}
+
+if [ ${#@} -gt 0 ]; then
+    # if arguments are passed in, just run the commands
+    $@
+else
+    echo "API Server: ${GUNICORN_SERVER}...";
+
+    if [ "$GUNICORN_SERVER" == "flask" ]; then
+        echo "Starting ${GUNICORN_API_DIR}/app.py...";
+        exec ${GUNICORN_API_DIR}/app.py;
+    else
+        gunicorn_run;
+    fi
+fi


### PR DESCRIPTION
This PR does a few things:

## Major Change


### Custom Options

This PR adds a startup.sh file which allows customizing the gunicorn options with the following environment variables:

```
ENV GUNICORN_SERVER gunicorn
ENV GUNICORN_WORKER_CLASS eventlet
ENV GUNICORN_WORKERS 1
ENV GUNICORN_LOGGING_CONFIG /app/logging.conf
ENV GUNICORN_TIMEOUT 300
ENV GUNICORN_BIND_ADDRESS 0.0.0.0
ENV GUNICORN_BIND_PORT 5000
ENV GUNICORN_DEBUG 0
ENV GUNICORN_RELOAD 0
ENV GUNICORN_OPTS ""
```

In addition, some API specific environment variables are set. 
```
ENV API_UPLOAD_DIR /opt/faction/uploads
ENV POSTGRES_HOST db
ENV POSTGRES_DATABASE faction
ENV POSTGRES_USERNAME postgres
ENV RABBIT_HOST mq
ENV RABBIT_USERNAME guest
ENV USE_NATIVE_LOGGER 0
# this is only used when GUNICORN_SERVER is "flask"
ENV DEFAULT_LOGGING_LEVEL INFO
```
However, the secrets (db password, flask secret, rabbit password)  are not given defaults to force the user to set them if they wish to use environment variables. 

### Watching and Reloading

If the project is mounted via volumes, and the GUNICORN_TIMEOUT is set to a low value (like 3 or 5 seconds), when code is changes on the host, gunicorn will restart the server (assuming GUNICORN_RELOAD is set). It still throws an exception which can be ignored. I have not tested with websocket stuff as the reload might break the socketio server but the core http server successfully restarts. This allows for a smoother developer experience. 

## Minor Changes

- adds an output handler to the file logger if using the embedded "flask" server
- creates a preexisting /opt/faction/uploads folder in the container which gunicorn owns to avoid permission errors
- installs pip dependencies before adding the project for better caching when building with docker 


This PR is part of my goal to create a simple developer environment via docker-compose: https://github.com/3lpsy/FactionCompose